### PR TITLE
[PKG-2515] ua-parser 0.18.0

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sfe1ed40
-channels:
-  - sfe1ed40
-upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sfe1ed40
+channels:
+  - sfe1ed40
+upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,5 @@
+upload_channels:
+  - sk_test
+
+channels:
+  - sk_test

--- a/abs.yaml
+++ b/abs.yaml
@@ -2,3 +2,4 @@ upload_channels:
   - sk_test
 channels:
   - sk_test
+upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,5 +1,0 @@
-upload_channels:
-  - sk_test
-channels:
-  - sk_test
-upload_without_merge: True

--- a/abs.yaml
+++ b/abs.yaml
@@ -9,3 +9,4 @@ channels:
 
 
 
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -4,3 +4,4 @@ upload_channels:
 channels:
   - sk_test
 
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -7,3 +7,4 @@ channels:
 
 
 
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -14,3 +14,4 @@ channels:
 
 
 
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -11,3 +11,4 @@ channels:
 
 
 
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -12,3 +12,4 @@ channels:
 
 
 
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -6,3 +6,4 @@ channels:
 
 
 
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -13,3 +13,4 @@ channels:
 
 
 
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -8,3 +8,4 @@ channels:
 
 
 
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -10,3 +10,4 @@ channels:
 
 
 
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -5,3 +5,4 @@ channels:
   - sk_test
 
 
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -3,3 +3,4 @@ upload_channels:
 
 channels:
   - sk_test
+

--- a/abs.yaml
+++ b/abs.yaml
@@ -1,18 +1,4 @@
 upload_channels:
   - sk_test
-
 channels:
   - sk_test
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/abs.yaml
+++ b/abs.yaml
@@ -15,3 +15,4 @@ channels:
 
 
 
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,41 +1,46 @@
-{% set version = "0.16.1" %}
+{% set name = 'ua-parser' %}
+{% set version = "0.18.0" %}
 
 package:
-  name: ua-parser
+  name: {{ name }}
   version: {{ version }}
 
 source:
-  url: https://pypi.org/packages/source/u/ua-parser/ua-parser-{{ version }}.tar.gz
-  sha256: ed3efc695f475ffe56248c9789b3016247e9c20e3556cfa4d5aadc78ab4b26c6
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  sha256: db51f1b59bfaa82ed9e2a1d99a54d3e4153dddf99ac1435d51828165422e624e
 
 build:
   number: 0
-  noarch: python
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:
-    - python >=3.6
+    - python
     - pip
-    - pyyaml >=5.4.0,<=5.5
+    - pyyaml
+    - setuptools
+    - wheel
   run:
-    - python >=3.6
+    - python
 
 test:
   imports:
     - ua_parser
-  commands:
-    - pip check
   requires:
     - pip
+  commands:
+    - pip check
 
 about:
   home: https://github.com/ua-parser/uap-python
   license: Apache-2.0
   license_file: ua_parser/LICENSE
   license_family: Apache
-  summary: Python port of Browserscope's user agent parser
+  summary: A python implementation of the UA Parser
+  description: |
+    A python implementation of the UA Parser.
   dev_url: https://github.com/ua-parser/uap-python
+  doc_url: https://github.com/ua-parser/uap-python
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
License: https://github.com/ua-parser/uap-python/blob/0.x/ua_parser/LICENSE
Requirements: https://github.com/ua-parser/uap-python/blob/0.x/setup.py

Actions:
1. Clean up the recipe:
- Add a jinja2 variable `name`
- Remove `noarch` python
- Add flags `--no-deps --no-build-isolation` to `script`
- Add missing `setuptools` & `wheel` to `host`
- Fix `python` in `host` and `run`
2. Remove `pyyaml` pin following the upstream requirements https://github.com/ua-parser/uap-python/blob/ae6398d219ba4b717e50f64be94f0c8e9768e16b/setup.py#L213
3. Add `doc_url`
4. Update `summary`
5. Add a `description`